### PR TITLE
worflow typo correction. Include k

### DIFF
--- a/site/docs/getting-started.md
+++ b/site/docs/getting-started.md
@@ -12,7 +12,7 @@ There are two options of installing Fricitonless Repository, as a new workflow o
 
 Add a file shown below in your Github Repository:
 
-> .github/worflows/frictionless.yaml
+> .github/workflows/frictionless.yaml
 
 ```yaml
 name: frictionless
@@ -41,7 +41,7 @@ jobs:
 
 Just add this step to an existent workflow:
 
-> .github/worflows/(name).yaml
+> .github/workflows/(name).yaml
 
 ```yaml
 - name: Validate data

--- a/site/docs/introduction.md
+++ b/site/docs/introduction.md
@@ -29,7 +29,7 @@ Frictionless Data is a comprehensive data software and standards project coverin
 - [Frictionless Components](https://components.frictionlessdata.io/?path=/story/components-report--invalid)
 
 Frictionless Repository can be described by this simple flow:
-- you add a Frictionless Repository step to their worflow on Github
+- you add a Frictionless Repository step to their workflow on Github
 - Frictionless Framework validates your data and saves the result as a workflow's artifact
 - Frictionless Components fetch and render this validation report
 


### PR DESCRIPTION
# Overview

Hello guys!!! First of all congratulation on the amazing work you are doing here. We've been using [frictionless specifications](https://specs.frictionlessdata.io//) a lot and now the possibility to [validate data in our GitHub repositories](https://repository.frictionlessdata.io/) is quite impressive. Tanks a lot!

Yesterday reading the documentation I've found a little typo that I want to suggest a correction.  As a follow these instructions in one project online validation didn't start as I was expecting. It cost me some time to realize that the problem was this little typo in .github/worflow folder name!!! Awesome

To test if the problem was exactly this one I've created two tests:

[This with the folder's wrong name](https://github.com/dados-mg/datapackage-reprex/tree/frictionless-online-validate-whith-folder-typo)
[This with the folder's correct name](https://github.com/dados-mg/datapackage-reprex/tree/frictionless-online-validate-whith-folder-typo-correction)

As you can see [validation started and work](https://repository.frictionlessdata.io/report/?user=dados-mg&repo=datapackage-reprex&flow=frictionless&run=942765191) only in the second one

So, That's why I'm suggesting this documentation improvement here! 

---

Please preserve this line to notify @roll (lead of this repository)
